### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Build & Publish to Docker Hub
-              uses: elgohr/Publish-Docker-Github-Action@v4
+              uses: elgohr/Publish-Docker-Github-Action@v5
               with:
                   name: bpkennedy/pardes
                   username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore